### PR TITLE
fix(icon): Resolve icon visibility issue with CSS registration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -178,6 +178,41 @@ Configured in `rector.php`:
 - Extra attributes passed through `extraAttributes()` method
 - Override `setUp()` for initialization (call `parent::setUp()` first)
 
+### CSS & Asset Management
+
+Package assets are managed via Filament's Asset Manager:
+
+**Automatic CSS Loading:**
+```php
+// In service provider
+use Filament\Support\Assets\Css;
+use Filament\Support\Facades\FilamentAsset;
+
+public function packageBooted(): void
+{
+    FilamentAsset::register([
+        Css::make('barcode-scanner-field', __DIR__ . '/../resources/css/barcode-scanner-field.css')
+            ->loadedOnRequest(),
+    ], 'marcelorodrigo/filament-barcode-scanner-field');
+}
+```
+
+**In Blade templates:**
+```blade
+<div x-load-css="[@js(\Filament\Support\Facades\FilamentAsset::getStyleHref('barcode-scanner-field', 'marcelorodrigo/filament-barcode-scanner-field'))]">
+```
+
+**Publishable Assets:**
+Enable via `$package->hasAssets()` in `configurePackage()`. Users can customize:
+```bash
+php artisan vendor:publish --tag=filament-barcode-scanner-field-assets
+```
+
+**CSS Conventions:**
+- Use `fi-` prefix for custom CSS classes (e.g., `.fi-barcode-scanner-icon`)
+- CSS loads automatically when component is used (no manual include needed)
+- Assets are located in `resources/css/`
+
 ### File Organization
 
 ```
@@ -186,6 +221,11 @@ src/
 ├── Facades/               # Laravel facades
 ├── Testing/               # Testing traits
 ├── *.php                  # Service providers, main class
+
+resources/
+├── css/                   # CSS assets (auto-loaded via Filament Asset Manager)
+├── lang/                  # Translation files
+└── views/                 # Blade templates
 
 tests/
 ├── Unit/                  # Unit tests (isolated components)
@@ -200,4 +240,5 @@ tests/
 
 - Located in `resources/views/components/`
 - Use `x-load-js` for loading external JavaScript (Alpine.js pattern)
+- Use `x-load-css` for loading package CSS via Filament Asset Manager
 - Component views referenced via `static::$viewNamespace` (e.g., `filament-barcode-scanner-field::components.barcode-input`)

--- a/resources/css/barcode-scanner-field.css
+++ b/resources/css/barcode-scanner-field.css
@@ -1,0 +1,5 @@
+/* Barcode Scanner Field Styles */
+.fi-barcode-scanner-icon {
+    width: 1.25rem;
+    height: 1.25rem;
+}

--- a/resources/views/components/barcode-input.blade.php
+++ b/resources/views/components/barcode-input.blade.php
@@ -1,5 +1,5 @@
 @php
-    use function Filament\Support\prepare_inherited_attributes;
+    use Filament\Support\Facades\FilamentAsset;use function Filament\Support\prepare_inherited_attributes;
     $fieldWrapperView = $getFieldWrapperView();
     $datalistOptions = $getDatalistOptions();
     $extraAlpineAttributes = $getExtraAlpineAttributes();
@@ -41,6 +41,7 @@
 >
     <div xmlns:x-filament="http://www.w3.org/1999/html"
          x-load-js="['https://unpkg.com/html5-qrcode@2.3.8/html5-qrcode.min.js']"
+         x-load-css="[@js(FilamentAsset::getStyleHref('barcode-scanner-field', 'marcelorodrigo/filament-barcode-scanner-field'))]"
          x-on:close-modal.window="stopScanning()"
          x-data="{
         html5QrcodeScanner: null,
@@ -75,13 +76,10 @@
                 <input {{ $inputAttributes->class(['fi-input']) }} />
 
                 <x-slot name="suffix">
-                    <!-- Trigger Button for Filament Modal -->
-                    <button type="button" @click="openScannerModal()"
-                            class="flex h-full items-center justify-center pr-3 focus:outline-hidden"
+                    <button type="button" x-on:click="openScannerModal()"
+                            class="flex items-center justify-center w-9 h-9 -my-2 text-gray-400 dark:text-gray-200 hover:text-gray-500 dark:hover:text-gray-300 transition-colors rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700"
                             aria-label="{{ __('filament-barcode-scanner-field::barcode-scanner-field.actions.scan_qrcode') }}">
-                        <span class="text-gray-400 dark:text-gray-200">
-                            <x-dynamic-component :component="$getIcon()" class="w-5 h-5" />
-                        </span>
+                        <x-dynamic-component :component="$getIcon()" class="fi-barcode-scanner-icon" />
                     </button>
                 </x-slot>
             </x-filament::input.wrapper>

--- a/resources/views/components/barcode-input.blade.php
+++ b/resources/views/components/barcode-input.blade.php
@@ -1,5 +1,6 @@
 @php
-    use Filament\Support\Facades\FilamentAsset;use function Filament\Support\prepare_inherited_attributes;
+    use Filament\Support\Facades\FilamentAsset;
+    use function Filament\Support\prepare_inherited_attributes;
     $fieldWrapperView = $getFieldWrapperView();
     $datalistOptions = $getDatalistOptions();
     $extraAlpineAttributes = $getExtraAlpineAttributes();

--- a/src/FilamentBarcodeScannerFieldServiceProvider.php
+++ b/src/FilamentBarcodeScannerFieldServiceProvider.php
@@ -2,6 +2,8 @@
 
 namespace Marcelorodrigo\FilamentBarcodeScannerField;
 
+use Filament\Support\Assets\Css;
+use Filament\Support\Facades\FilamentAsset;
 use Spatie\LaravelPackageTools\Commands\InstallCommand;
 use Spatie\LaravelPackageTools\Package;
 use Spatie\LaravelPackageTools\PackageServiceProvider;
@@ -11,6 +13,13 @@ class FilamentBarcodeScannerFieldServiceProvider extends PackageServiceProvider
     public static string $name = 'filament-barcode-scanner-field';
 
     public static string $viewNamespace = 'filament-barcode-scanner-field';
+
+    public function packageBooted(): void
+    {
+        FilamentAsset::register([
+            Css::make('barcode-scanner-field', __DIR__ . '/../resources/css/barcode-scanner-field.css')->loadedOnRequest(),
+        ], 'marcelorodrigo/filament-barcode-scanner-field');
+    }
 
     public function configurePackage(Package $package): void
     {
@@ -41,6 +50,10 @@ class FilamentBarcodeScannerFieldServiceProvider extends PackageServiceProvider
 
         if (file_exists($package->basePath('/../resources/views'))) {
             $package->hasViews(static::$viewNamespace);
+        }
+
+        if (file_exists($package->basePath('/../resources/css'))) {
+            $package->hasAssets();
         }
     }
 

--- a/src/FilamentBarcodeScannerFieldServiceProvider.php
+++ b/src/FilamentBarcodeScannerFieldServiceProvider.php
@@ -14,6 +14,7 @@ class FilamentBarcodeScannerFieldServiceProvider extends PackageServiceProvider
 
     public static string $viewNamespace = 'filament-barcode-scanner-field';
 
+    #[\Override]
     public function packageBooted(): void
     {
         FilamentAsset::register([

--- a/tests/Feature/BarcodeInputIntegrationTest.php
+++ b/tests/Feature/BarcodeInputIntegrationTest.php
@@ -46,10 +46,10 @@ describe('BarcodeInput Integration Tests', function () {
     });
 
     describe('Tailwind CSS Classes', function () {
-        it('renders icon with Tailwind sizing classes', function () {
+        it('renders icon with CSS class', function () {
             livewire(TestBarcodeFormComponent::class)
                 ->assertOk()
-                ->assertSee('w-5 h-5', false);
+                ->assertSee('fi-barcode-scanner-icon', false);
         });
 
         it('renders input with full width class', function () {
@@ -61,7 +61,7 @@ describe('BarcodeInput Integration Tests', function () {
         it('renders icon button with flex layout', function () {
             livewire(TestBarcodeFormComponent::class)
                 ->assertOk()
-                ->assertSee('flex h-full items-center', false);
+                ->assertSee('flex items-center justify-center', false);
         });
 
         it('renders input with padding for icon', function () {

--- a/tests/Feature/BarcodeInputIntegrationTest.php
+++ b/tests/Feature/BarcodeInputIntegrationTest.php
@@ -45,7 +45,7 @@ describe('BarcodeInput Integration Tests', function () {
         });
     });
 
-    describe('Tailwind CSS Classes', function () {
+    describe('CSS Classes', function () {
         it('renders icon with CSS class', function () {
             livewire(TestBarcodeFormComponent::class)
                 ->assertOk()


### PR DESCRIPTION
Fix icon visibility by extracting inline styles to a dedicated CSS file with automatic loading via Filament Asset Manager.

**Problem:**
The barcode scanner icon was rendering at 0x0 dimensions because SVG elements inside the suffix slot weren't receiving proper sizing from Tailwind classes.

**Solution:**
- Created 
- Registered CSS via 
- Updated Blade template to use CSS class instead of inline styles
- Added 
- Enabled asset publishing with 

**Benefits:**
- CSS loads automatically when component is used (no user action required)
- Users can customize styling by publishing assets:
  
- Follows Filament plugin best practices with proper asset management
- All 105 tests passing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Added a dedicated CSS file for the barcode scanner icon, refined icon sizing and button layout, and adjusted interaction markup so scanner styles apply consistently.
* **Documentation**
  * Added a “CSS & Asset Management” section and updated component/Blade guidance to show the new CSS loading approach.
* **Tests**
  * Updated tests to reflect the new CSS class and layout assertions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->